### PR TITLE
Handle case where student is invited but not enrolled

### DIFF
--- a/cornellGrading/cornellGrading.py
+++ b/cornellGrading/cornellGrading.py
@@ -133,6 +133,9 @@ class cornellGrading:
                     isstudent = e["role"] == "StudentEnrollment"
 
             if isstudent:
+                if not hasattr(t, 'login_id'):
+                    print(f'Warning: Skipping {t.sortable_name}: is in the course, but not enrolled.')
+                    continue
                 names.append(t.sortable_name)
                 ids.append(t.id)
                 netids.append(t.login_id)


### PR DESCRIPTION
This fixes the bug where, for manually invited students, the code breaks when one or more haven't accepted the invitation yet.